### PR TITLE
Support exe files with additional suffix after test

### DIFF
--- a/GoogleTestRunner/GoogleTestDiscoverer.fs
+++ b/GoogleTestRunner/GoogleTestDiscoverer.fs
@@ -13,7 +13,7 @@ module Constants =
 
 module DiscovererUtils =
     let isGoogleTestExecutable (logger:IMessageLogger) e =
-        let executablesAllowed = "[Tt]est[s]{0,1}.exe"
+        let executablesAllowed = "[Tt]est[s]?(?:[-_].*)?.exe"
         let matches = Regex.IsMatch(e, executablesAllowed)
         logger.SendMessage(TestMessageLevel.Informational,
             sprintf "GoogleTest: Does %s match %s: %b" e executablesAllowed matches)


### PR DESCRIPTION
Support test with suffix like "mylib_test-vc90-mt-sgd-32.exe"

Sorry, I don't know how to write tests in F#.