### PR TITLE
Fixed parameterized tests with non trivial Param type

### DIFF
--- a/GoogleTestRunner/GoogleTestDiscoverer.fs
+++ b/GoogleTestRunner/GoogleTestDiscoverer.fs
@@ -24,7 +24,8 @@ module DiscovererUtils =
         let parseSingleTest (currentSuite, result) (currentLine:string) =
             let currentLine = currentLine.Trim([|'.'; '\n'; '\r'|])
             if currentLine.StartsWith("  ") then
-                currentSuite, (currentSuite, currentLine.Substring(2)) :: result
+                let caseName = currentLine.Split([|' '|], StringSplitOptions.RemoveEmptyEntries).[0]
+                currentSuite, (currentSuite, caseName) :: result
             else
                 let stripGtest170TypeParameter =
                     let split = currentLine.Split([|".  # TypeParam"|], StringSplitOptions.RemoveEmptyEntries)
@@ -33,7 +34,11 @@ module DiscovererUtils =
         snd (tests |> List.fold parseSingleTest ("", List.empty)) |> Array.ofList
         
     /// Gets the GoogleTest function name format!
-    let googleTestCombinedName (testSuite, testMethod) = sprintf "%s_%s_Test%s" testSuite testMethod Constants.gtestTestBodySignature
+    let googleTestCombinedName (testSuite: string, testMethod: string) = 
+        let testSuiteName = testSuite.Split([|'/'|], StringSplitOptions.RemoveEmptyEntries) :> seq<string> |> Seq.last
+        let testMethodName = testMethod.Split([|'/'|], StringSplitOptions.RemoveEmptyEntries).[0]
+        sprintf "%s_%s_Test%s" testSuiteName testMethodName Constants.gtestTestBodySignature
+
     let getSourceFileLocations executable logger (testcases:(string * string) []) =
         let symbols = testcases |> Array.Parallel.map googleTestCombinedName
         let symbolFilterString = sprintf "*%s" Constants.gtestTestBodySignature

--- a/GoogleTestRunner/GoogleTestDiscoverer.fs
+++ b/GoogleTestRunner/GoogleTestDiscoverer.fs
@@ -54,12 +54,17 @@ module DiscovererUtils =
             match symbols |> Array.tryFind(fun ((f:string), (a, b)) -> f.Contains(cn)) with
             | None -> sprintf "Couldn't locate %s" cn, -12
             | Some(info) -> snd info
-        TestCase(dn,
+        let category = testSuite.Split([|'/'|], StringSplitOptions.RemoveEmptyEntries) :> seq<string> |> Seq.last
+        let testCase = 
+            TestCase(
+                dn,
                 Uri(Constants.identifierUri),
                 executable,
                 DisplayName = dn,
                 CodeFilePath = fst sourceInfo,
                 LineNumber = snd sourceInfo)
+        testCase.Traits.Add(Trait("Category", category))
+        testCase
 
     let getTestsFromExecutable (logger:IMessageLogger) executable =
         let gtestTestList = ProcessUtil.getOutputOfCommand(String.Empty, executable, Constants.gtestListTests, true)

--- a/GoogleTestRunnerTests/GoogleTestDiscovererTest.fs
+++ b/GoogleTestRunnerTests/GoogleTestDiscovererTest.fs
@@ -115,17 +115,19 @@ type ``GoogleTestDiscoverer`` () =
     [<TestMethod>] member x.``parses test case list from googletest 1.7.0 parameterized output`` () =
                     let result = DiscovererUtils.parseTestCases (gtest170ParameterizedMethods.Split([|'\n'|]) |> List.ofArray)
                     result.Length |> should equal 27
-                    result.[0] |> should equal ("ParameterizedTestsTest4/DISABLED_ClassDisabledTest", "TestInstance/2  # GetParam() = 100")
-                    result.[1] |> should equal ("ParameterizedTestsTest4/DISABLED_ClassDisabledTest", "TestInstance/1  # GetParam() = 0")
-                    result.[2] |> should equal ("ParameterizedTestsTest4/DISABLED_ClassDisabledTest", "TestInstance/0  # GetParam() = -100")
-                    result.[3] |> should equal ("ParameterizedTestsTest3/NameDisabledTest", "DISABLED_TestInstance/2  # GetParam() = 100")
-                    result.[4] |> should equal ("ParameterizedTestsTest3/NameDisabledTest", "DISABLED_TestInstance/1  # GetParam() = 0")
-                    result.[5] |> should equal ("ParameterizedTestsTest3/NameDisabledTest", "DISABLED_TestInstance/0  # GetParam() = -100")
-                    result.[6] |> should equal ("DISABLED_ParameterizedTestsTest2/InstantiateDisabledTest", "TestInstance/2  # GetParam() = 100")
-                    result.[7] |> should equal ("DISABLED_ParameterizedTestsTest2/InstantiateDisabledTest", "TestInstance/1  # GetParam() = 0")
-                    result.[8] |> should equal ("DISABLED_ParameterizedTestsTest2/InstantiateDisabledTest", "TestInstance/0  # GetParam() = -100")
-                    result.[9] |> should equal ("ParameterizedTestsTest1/AllEnabledTest", "TestInstance/17  # GetParam() = (true, 200, 100)")
-                    result.[10] |> should equal ("ParameterizedTestsTest1/AllEnabledTest", "TestInstance/16  # GetParam() = (true, 200, 0)")
+                    result.[0] |> should equal ("ParameterizedTestsTest4/DISABLED_ClassDisabledTest", "TestInstance/2")
+                    result.[1] |> should equal ("ParameterizedTestsTest4/DISABLED_ClassDisabledTest", "TestInstance/1")
+                    result.[2] |> should equal ("ParameterizedTestsTest4/DISABLED_ClassDisabledTest", "TestInstance/0")
+                    result.[3] |> should equal ("ParameterizedTestsTest3/NameDisabledTest", "DISABLED_TestInstance/2")
+                    result.[4] |> should equal ("ParameterizedTestsTest3/NameDisabledTest", "DISABLED_TestInstance/1")
+                    result.[5] |> should equal ("ParameterizedTestsTest3/NameDisabledTest", "DISABLED_TestInstance/0")
+                    result.[6] |> should equal ("DISABLED_ParameterizedTestsTest2/InstantiateDisabledTest", "TestInstance/2")
+                    result.[7] |> should equal ("DISABLED_ParameterizedTestsTest2/InstantiateDisabledTest", "TestInstance/1")
+                    result.[8] |> should equal ("DISABLED_ParameterizedTestsTest2/InstantiateDisabledTest", "TestInstance/0")
+                    result.[9] |> should equal ("ParameterizedTestsTest1/AllEnabledTest", "TestInstance/17")
+                    result.[10] |> should equal ("ParameterizedTestsTest1/AllEnabledTest", "TestInstance/16")
+
+
 
     [<TestMethod>] member x.``parses test case list from googletest 1.7.0 output`` () =
                     let result = DiscovererUtils.parseTestCases (gtest170TypedMethods.Split([|'\n'|]) |> List.ofArray)


### PR DESCRIPTION
There is an issue with non trivial Parameters type in.
Here is an example:
`enum class MyEnum { One, Two };`
`struct TestCaseParam { const char* name; MyEnum enumVal; };`
`class TestCase : public testing::TestWithParam<TestCaseParam>`

`INSTANTIATE_TEST_CASE_P(Prefix, TestCase, testing::Values(`
`TestCaseParam{ "Name", MyEnum::One }`
`));`

`TEST_P(TestCase, test)`
`{ ... }`

First issue:
Test Explorer cannot deal with `test\0 #GetParam() = <structure binary>` in this case. So my fix just removes the `#GetParam ...` part.

Second issue:
In this example testSuite will be `Prefix\TestCase` and testMethod will be `test\0 #GetParam() = bla-bla-bla`
and adapter will be trying to find `Prefix\TestCase_test\0_Test::TestBody()` method and of course cannot find it. So we need transform this path to `TestCase_test_Test::TestBody()` one.
