### PR TITLE
Look for PDB file with two possible names

### DIFF
--- a/GoogleTestRunner/DiaResolver.fs
+++ b/GoogleTestRunner/DiaResolver.fs
@@ -42,7 +42,7 @@ let private findSymbolsFromExecutable symbols symbolFilterString (logger : IMess
 
     let sw = System.Diagnostics.Stopwatch.StartNew()
     let diaDataSource = DiaSourceClass()
-    let path = Path.ReplaceExtension(executable, ".pdb")
+    let path = [Path.ReplaceExtension(executable, ".pdb"); executable + ".pdb"] |> Seq.find File.Exists
 
     DiaMemoryStream(path) |> diaDataSource.loadDataFromIStream
     let diaSession = diaDataSource.openSession()


### PR DESCRIPTION
PDB may either be named "foo.pdb" or "foo.exe.pdb" (Chromium uses the latter).
